### PR TITLE
Fix  layout

### DIFF
--- a/src/components/ActionButtons/LikesButton.jsx
+++ b/src/components/ActionButtons/LikesButton.jsx
@@ -4,6 +4,8 @@ import { RiHeartAddLine, RiDislikeLine } from "react-icons/ri";
 import styles from "./ActionButton.module.css";
 import React from "react";
 import { useAuth } from "../../contexts/providers/AuthProvider";
+import { useLocation, useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
 function LikesButton({ video, text = false }) {
   const {
@@ -15,11 +17,23 @@ function LikesButton({ video, text = false }) {
     authState: { token },
   } = useAuth();
 
+  const navigate = useNavigate();
+  const location = useLocation();
+  const navigateToLogin = () => {
+    toast.info("You need to login first!");
+
+    navigate("/login", { state: { from: location } });
+  };
+
   return likes.some((item) => item._id === video._id) ? (
     <button
       className={styles.action_btn_active}
       onClick={(e) => {
         e.stopPropagation();
+        if (!token) {
+          navigateToLogin();
+          return;
+        }
         deleteFromLikes(video._id, token, userDataDispatch);
       }}
     >
@@ -31,6 +45,10 @@ function LikesButton({ video, text = false }) {
       className={styles.action_btn}
       onClick={(e) => {
         e.stopPropagation();
+        if (!token) {
+          navigateToLogin();
+          return;
+        }
         addToLikes({ video: video }, token, userDataDispatch);
       }}
     >

--- a/src/components/ActionButtons/PlaylistButton.jsx
+++ b/src/components/ActionButtons/PlaylistButton.jsx
@@ -3,13 +3,28 @@ import styles from "./ActionButton.module.css";
 import { CgPlayListAdd } from "react-icons/cg";
 import PlaylistModal from "../PlaylistModal/PlaylistModal";
 import { useToggle } from "../../hooks";
+import { useNavigate, useLocation } from "react-router-dom";
+import { toast } from "react-toastify";
+import { useAuth } from "../../contexts/providers/AuthProvider";
 
 function PlaylistButton({ video, text = false }) {
   const {
     state: { playlists },
   } = useUserData();
 
+  const {
+    authState: { token },
+  } = useAuth();
+
   const { toggle: modalToggle, setToggle: setModalToggle } = useToggle(false);
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const navigateToLogin = () => {
+    toast.info("You need to login first!");
+
+    navigate("/login", { state: { from: location } });
+  };
 
   const videoInPlaylists = playlists.some((playlist) =>
     playlist.videos.some((item) => item._id === video._id)
@@ -24,6 +39,10 @@ function PlaylistButton({ video, text = false }) {
         }
         onClick={(e) => {
           e.stopPropagation();
+          if (!token) {
+            navigateToLogin();
+            return;
+          }
           setModalToggle(true);
         }}
       >

--- a/src/components/ActionButtons/WatchLaterButton.jsx
+++ b/src/components/ActionButtons/WatchLaterButton.jsx
@@ -3,6 +3,8 @@ import { addToWatchLater, deleteFromWatchLater } from "../../services";
 import styles from "./ActionButton.module.css";
 import { MdOutlineWatchLater } from "react-icons/md";
 import { useAuth } from "../../contexts/providers/AuthProvider";
+import { useNavigate, useLocation } from "react-router-dom";
+import { toast } from "react-toastify";
 
 const WatchLaterButton = ({ video, text = false }) => {
   const {
@@ -14,11 +16,23 @@ const WatchLaterButton = ({ video, text = false }) => {
     authState: { token },
   } = useAuth();
 
+  const navigate = useNavigate();
+  const location = useLocation();
+  const navigateToLogin = () => {
+    toast.info("You need to login first!");
+
+    navigate("/login", { state: { from: location } });
+  };
+
   return watchlater.some((item) => item._id === video._id) ? (
     <button
       className={styles.action_btn_active}
       onClick={(e) => {
         e.stopPropagation();
+        if (!token) {
+          navigateToLogin();
+          return;
+        }
         deleteFromWatchLater(video._id, token, userDataDispatch);
       }}
     >
@@ -30,6 +44,10 @@ const WatchLaterButton = ({ video, text = false }) => {
       className={styles.action_btn}
       onClick={(e) => {
         e.stopPropagation();
+        if (!token) {
+          navigateToLogin();
+          return;
+        }
         addToWatchLater({ video: video }, token, userDataDispatch);
       }}
     >

--- a/src/components/Card/VideoCard/VideoCard.jsx
+++ b/src/components/Card/VideoCard/VideoCard.jsx
@@ -14,7 +14,6 @@ import { useNavigate } from "react-router-dom";
 function VideoCard({ video, type }) {
   const { dispatch: userDataDispatch } = useUserData();
   const navigate = useNavigate();
-
   const {
     authState: { token },
   } = useAuth();
@@ -90,8 +89,7 @@ function VideoCard({ video, type }) {
             <p>{views.toLocaleString()} views</p> • <p>{dateUploaded}</p>
           </span>
         </div>
-
-        {token && type === "default" && (
+        {type === "default" && (
           <span className={`${styles.action_btn_wrapper} flex-row`}>
             <WatchLaterButton video={video} />
             <LikesButton video={video} />

--- a/src/components/Card/VideoCard/VideoCard.module.css
+++ b/src/components/Card/VideoCard/VideoCard.module.css
@@ -6,6 +6,7 @@
   font-family: sans-serif;
   height: 18rem;
   transition: all 0.2s linear;
+  background-color: #1e1d1d;
 }
 
 .video_card:hover {

--- a/src/components/VideoGrid/VideoGrid.jsx
+++ b/src/components/VideoGrid/VideoGrid.jsx
@@ -2,9 +2,18 @@ import React from "react";
 import styles from "./VideoGrid.module.css";
 import { VideoCard } from "../index";
 
-function VideoGrid({ videos = [], classNames, type = "default" }) {
+function VideoGrid({
+  videos = [],
+  classNames,
+  type = "default",
+  alignCenter = false,
+}) {
   return (
-    <div className={`${styles.videos_wrapper} ${classNames}`}>
+    <div
+      className={`${styles.videos_wrapper} ${classNames} ${
+        alignCenter && styles.align_center
+      } `}
+    >
       {videos.map((video) => (
         <VideoCard key={video._id} video={video} type={type} />
       ))}

--- a/src/components/VideoGrid/VideoGrid.module.css
+++ b/src/components/VideoGrid/VideoGrid.module.css
@@ -1,7 +1,11 @@
 .videos_wrapper{
     display: grid;
-    grid-template-columns: repeat(auto-fit, 24.5rem);
+    grid-template-columns: repeat(auto-fit, 22.5rem);
     padding: var(--rem-1);
     gap:var(--rem-0-5);
+}
+
+.align_center{
     justify-content: center;
 }
+

--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,16 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--color-bg-black);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-primary);
+  border-radius: var(--rem-2);
+} 

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -94,7 +94,7 @@ function Login() {
           }
           autoComplete={"current-password"}
         />
-        {/* Only for illustration, functioning will be added later! */}
+        {/* Only for illustration, functionality will be added later! */}
         <span className={`${styles.form_span} flex-row`}>
           <label>
             <input type="checkbox" />

--- a/src/pages/Video/Video.jsx
+++ b/src/pages/Video/Video.jsx
@@ -76,22 +76,20 @@ function Video() {
               </span>
             </div>
           </div>
-          {isAuthenticated && (
-            <span className={`${styles.actionBtns} flex-row`}>
-              <PlaylistButton
-                text={screenWidth > 520 ? true : false}
-                video={video}
-              />
-              <WatchLaterButton
-                text={screenWidth > 520 ? true : false}
-                video={video}
-              />
-              <LikesButton
-                text={screenWidth > 520 ? true : false}
-                video={video}
-              />
-            </span>
-          )}
+          <span className={`${styles.actionBtns} flex-row`}>
+            <PlaylistButton
+              text={screenWidth > 520 ? true : false}
+              video={video}
+            />
+            <WatchLaterButton
+              text={screenWidth > 520 ? true : false}
+              video={video}
+            />
+            <LikesButton
+              text={screenWidth > 520 ? true : false}
+              video={video}
+            />
+          </span>
         </div>
       </div>
     </section>

--- a/src/pages/Videos/Videos.jsx
+++ b/src/pages/Videos/Videos.jsx
@@ -41,6 +41,7 @@ function Videos() {
         ))}
       </div>
       <VideoGrid
+        alignCenter={true}
         videos={
           currentCategory === "All"
             ? videos


### PR DESCRIPTION
## Fix: Layout
On the personalized pages such as Liked Videos, Watch Later and History the videos were being shown in the center which deteriorated the UX. Added a prop in the VideoGrid component to provide center/ flex-start position to children elements

## Other Changes
- Enabled visibility for card action buttons on the video page and VideoCard component. even when the user was not authenticated. When they click on them without being signed in, they're navigated to the login page. Upon successfully logging in, they're navigated back to the page they were before the earlier navigation.

Motive: Since the users can view and stream videos without signing in, the buttons not being shown would give the illusion that they do not exist and the app offers no such functionality, which is not the case. 

- Add a custom scrollbar
- Add background color to video cards to improve contrast and differentiate between background and videos